### PR TITLE
feat: getTransaction

### DIFF
--- a/src/RequestManager.ts
+++ b/src/RequestManager.ts
@@ -498,7 +498,7 @@ export class RequestManager {
         if (status.nonce < currentNonce) {
           const tx: ReplacedTransaction = {
             hash,
-            type: TransactionType.REPLACED,
+            type: TransactionType.replaced,
             nonce: status.nonce
           }
           return tx
@@ -508,7 +508,7 @@ export class RequestManager {
         if (status.nonce > currentNonce) {
           const tx: QueuedTransaction = {
             hash,
-            type: TransactionType.QUEUED,
+            type: TransactionType.queued,
             nonce: status.nonce
           }
           return tx
@@ -517,7 +517,7 @@ export class RequestManager {
 
       // pending
       const tx: PendingTransaction = {
-        type: TransactionType.PENDING,
+        type: TransactionType.pending,
         ...status
       }
       return tx
@@ -531,7 +531,7 @@ export class RequestManager {
       // reverted
       if (receipt == null || receipt.status === 0x0) {
         const tx: RevertedTransaction = {
-          type: TransactionType.REVERTED,
+          type: TransactionType.reverted,
           ...status
         }
         return tx
@@ -543,7 +543,7 @@ export class RequestManager {
 
     // confirmed
     const tx: ConfirmedTransaction = {
-      type: TransactionType.CONFIRMED,
+      type: TransactionType.confirmed,
       ...status,
       receipt
     }

--- a/src/RequestManager.ts
+++ b/src/RequestManager.ts
@@ -44,7 +44,8 @@ import {
   ReplacedTransaction,
   Transaction,
   RevertedTransaction,
-  ConfirmedTransaction
+  ConfirmedTransaction,
+  TransactionType
 } from './Schema'
 import BigNumber from 'bignumber.js'
 import { sleep } from './utils/sleep'
@@ -497,7 +498,7 @@ export class RequestManager {
         if (status.nonce < currentNonce) {
           const tx: ReplacedTransaction = {
             hash,
-            type: 'replaced',
+            type: TransactionType.REPLACED,
             nonce: status.nonce
           }
           return tx
@@ -507,7 +508,7 @@ export class RequestManager {
         if (status.nonce > currentNonce) {
           const tx: QueuedTransaction = {
             hash,
-            type: 'queued',
+            type: TransactionType.QUEUED,
             nonce: status.nonce
           }
           return tx
@@ -516,7 +517,7 @@ export class RequestManager {
 
       // pending
       const tx: PendingTransaction = {
-        type: 'pending',
+        type: TransactionType.PENDING,
         ...status
       }
       return tx
@@ -530,7 +531,7 @@ export class RequestManager {
       // reverted
       if (receipt == null || receipt.status === 0x0) {
         const tx: RevertedTransaction = {
-          type: 'reverted',
+          type: TransactionType.REVERTED,
           ...status
         }
         return tx
@@ -542,7 +543,7 @@ export class RequestManager {
 
     // confirmed
     const tx: ConfirmedTransaction = {
-      type: 'confirmed',
+      type: TransactionType.CONFIRMED,
       ...status,
       receipt
     }

--- a/src/RequestManager.ts
+++ b/src/RequestManager.ts
@@ -38,7 +38,13 @@ import {
   Syncing,
   TxHash,
   Address,
-  FilterOptions
+  FilterOptions,
+  QueuedTransaction,
+  PendingTransaction,
+  ReplacedTransaction,
+  Transaction,
+  RevertedTransaction,
+  ConfirmedTransaction
 } from './Schema'
 import BigNumber from 'bignumber.js'
 import { sleep } from './utils/sleep'
@@ -86,7 +92,7 @@ export class RequestManager {
   @inject web3_sha3: (data: Data) => Promise<Data>
 
   /** Returns the current network id. */
-  @inject net_version: () => Promise<number>
+  @inject net_version: () => Promise<string>
 
   /** Returns number of peers currently connected to the client. */
   @inject net_peerCount: () => Promise<Quantity>
@@ -459,6 +465,88 @@ export class RequestManager {
 
       await sleep(TRANSACTION_FETCH_DELAY)
     }
+  }
+
+  /**
+   * Returns a transaction in any of the possible states.
+   * @param hash - The transaction hash
+   */
+  async getTransaction(hash: string): Promise<Transaction> {
+    let currentNonce
+    let status
+    try {
+      const account = eth.eth_accounts[0]
+      currentNonce = await this.eth_getTransactionCount(account, 'latest')
+    } catch (error) {
+      currentNonce = null
+    }
+
+    try {
+      status = await this.eth_getTransactionByHash(hash)
+      // not found
+      if (status == null) {
+        return null
+      }
+    } catch (e) {
+      return null
+    }
+
+    if (status.blockNumber == null) {
+      if (currentNonce != null) {
+        // replaced
+        if (status.nonce < currentNonce) {
+          const tx: ReplacedTransaction = {
+            hash,
+            type: 'replaced',
+            nonce: status.nonce
+          }
+          return tx
+        }
+
+        // queued
+        if (status.nonce > currentNonce) {
+          const tx: QueuedTransaction = {
+            hash,
+            type: 'queued',
+            nonce: status.nonce
+          }
+          return tx
+        }
+      }
+
+      // pending
+      const tx: PendingTransaction = {
+        type: 'pending',
+        ...status
+      }
+      return tx
+    }
+
+    let receipt
+
+    try {
+      receipt = await this.eth_getTransactionReceipt(hash)
+
+      // reverted
+      if (receipt == null || receipt.status === 0x0) {
+        const tx: RevertedTransaction = {
+          type: 'reverted',
+          ...status
+        }
+        return tx
+      }
+    } catch (e) {
+      // TODO: should this be null or reverted?
+      return null
+    }
+
+    // confirmed
+    const tx: ConfirmedTransaction = {
+      type: 'confirmed',
+      ...status,
+      receipt
+    }
+    return tx
   }
 
   /*

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -161,6 +161,54 @@ export type TransactionObject = {
   s?: Data
 }
 
+export type Transaction =
+  | DroppedTransaction
+  | ReplacedTransaction
+  | QueuedTransaction
+  | PendingTransaction
+  | ConfirmedTransaction
+  | RevertedTransaction
+
+export type TransactionTypes = {
+  queued: 'queued'
+  dropped: 'dropped'
+  replaced: 'replaced'
+  pending: 'pending'
+  reverted: 'reverted'
+  confirmed: 'confirmed'
+}
+
+export type DroppedTransaction = {
+  type: TransactionTypes['dropped']
+  hash: string
+  nonce: number
+}
+
+export type ReplacedTransaction = {
+  type: TransactionTypes['replaced']
+  hash: string
+  nonce: number
+}
+
+export type QueuedTransaction = {
+  type: TransactionTypes['queued']
+  hash: string
+  nonce: number
+}
+
+export type PendingTransaction = TransactionObject & {
+  type: TransactionTypes['pending']
+}
+
+export type RevertedTransaction = TransactionObject & {
+  type: TransactionTypes['reverted']
+}
+
+export type ConfirmedTransaction = TransactionObject & {
+  type: TransactionTypes['confirmed']
+  receipt: TransactionReceipt
+}
+
 export type FilterLog = {}
 
 export type FilterOptions = {

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -169,43 +169,43 @@ export type Transaction =
   | ConfirmedTransaction
   | RevertedTransaction
 
-export type TransactionTypes = {
-  queued: 'queued'
-  dropped: 'dropped'
-  replaced: 'replaced'
-  pending: 'pending'
-  reverted: 'reverted'
-  confirmed: 'confirmed'
+export enum TransactionType {
+  QUEUED = 'queued',
+  DROPPED = 'dropped',
+  REPLACED = 'replaced',
+  PENDING = 'pending',
+  REVERTED = 'reverted',
+  CONFIRMED = 'confirmed'
 }
 
 export type DroppedTransaction = {
-  type: TransactionTypes['dropped']
+  type: TransactionType.DROPPED
   hash: string
   nonce: number
 }
 
 export type ReplacedTransaction = {
-  type: TransactionTypes['replaced']
+  type: TransactionType.REPLACED
   hash: string
   nonce: number
 }
 
 export type QueuedTransaction = {
-  type: TransactionTypes['queued']
+  type: TransactionType.QUEUED
   hash: string
   nonce: number
 }
 
 export type PendingTransaction = TransactionObject & {
-  type: TransactionTypes['pending']
+  type: TransactionType.PENDING
 }
 
 export type RevertedTransaction = TransactionObject & {
-  type: TransactionTypes['reverted']
+  type: TransactionType.REVERTED
 }
 
 export type ConfirmedTransaction = TransactionObject & {
-  type: TransactionTypes['confirmed']
+  type: TransactionType.CONFIRMED
   receipt: TransactionReceipt
 }
 

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -170,42 +170,42 @@ export type Transaction =
   | RevertedTransaction
 
 export enum TransactionType {
-  QUEUED = 'queued',
-  DROPPED = 'dropped',
-  REPLACED = 'replaced',
-  PENDING = 'pending',
-  REVERTED = 'reverted',
-  CONFIRMED = 'confirmed'
+  queued = 'queued',
+  dropped = 'dropped',
+  replaced = 'replaced',
+  pending = 'pending',
+  reverted = 'reverted',
+  confirmed = 'confirmed'
 }
 
 export type DroppedTransaction = {
-  type: TransactionType.DROPPED
+  type: TransactionType.dropped
   hash: string
   nonce: number
 }
 
 export type ReplacedTransaction = {
-  type: TransactionType.REPLACED
+  type: TransactionType.replaced
   hash: string
   nonce: number
 }
 
 export type QueuedTransaction = {
-  type: TransactionType.QUEUED
+  type: TransactionType.queued
   hash: string
   nonce: number
 }
 
 export type PendingTransaction = TransactionObject & {
-  type: TransactionType.PENDING
+  type: TransactionType.pending
 }
 
 export type RevertedTransaction = TransactionObject & {
-  type: TransactionType.REVERTED
+  type: TransactionType.reverted
 }
 
 export type ConfirmedTransaction = TransactionObject & {
-  type: TransactionType.CONFIRMED
+  type: TransactionType.confirmed
   receipt: TransactionReceipt
 }
 

--- a/src/methods/eth.ts
+++ b/src/methods/eth.ts
@@ -258,8 +258,7 @@ export namespace eth {
   })
 
   export const net_version = new Property({
-    getter: 'net_version',
-    outputFormatter: utils.toDecimal
+    getter: 'net_version'
   })
 
   export const shh_version = new Method({

--- a/test/helpers/FakeHttpProvider.ts
+++ b/test/helpers/FakeHttpProvider.ts
@@ -130,8 +130,8 @@ export class FakeHttpProvider {
       const responseIsArray = utils.isArray(this.response)
 
       if (responseIsArray !== requestIsArray) {
-        console.log(`Req: ${JSON.stringify(payload)}`)
-        console.log(`Res: ${JSON.stringify(this.response)}`)
+        console['log'](`Req: ${JSON.stringify(payload)}`)
+        console['log'](`Res: ${JSON.stringify(this.response)}`)
         throw new Error(`Request is array (${requestIsArray}) != response is array (${responseIsArray})`)
       }
 

--- a/test/integration.erc20.ts
+++ b/test/integration.erc20.ts
@@ -7,6 +7,7 @@ const expect = chai.expect
 import { ContractFactory, RequestManager } from '../src'
 import BigNumber from 'bignumber.js'
 import { testAllProviders } from './helpers/testAllProviders'
+import { ConfirmedTransaction } from '../src/Schema'
 
 declare var require
 
@@ -74,7 +75,7 @@ function doTest(requestManager: RequestManager) {
     expect(typeof txRecipt.status).to.eq('number')
   })
 
-  it('gets the trasaction', async () => {
+  it('gets the trasaction by hash', async () => {
     const x = await requestManager.eth_getTransactionByHash(ERC20Contract.transactionHash)
     expect(typeof x).eq('object')
     expect(x.hash).eq(ERC20Contract.transactionHash)
@@ -85,6 +86,55 @@ function doTest(requestManager: RequestManager) {
     expect(typeof x.blockHash).to.eq('string')
     expect(typeof x.hash).to.eq('string')
     expect(typeof x.transactionIndex).to.eq('number')
+  })
+
+  it('gets the transaction ', async () => {
+    const { receipt, ...tx } = (await requestManager.getTransaction(
+      ERC20Contract.transactionHash
+    )) as ConfirmedTransaction
+
+    const transactionFields = [
+      'type',
+      'hash',
+      'nonce',
+      'blockHash',
+      'blockNumber',
+      'transactionIndex',
+      'from',
+      'to',
+      'value',
+      'gas',
+      'gasPrice',
+      'input'
+    ]
+
+    const receiptFields = [
+      'transactionHash',
+      'transactionIndex',
+      'blockHash',
+      'blockNumber',
+      'gasUsed',
+      'cumulativeGasUsed',
+      'contractAddress',
+      'logs',
+      'status',
+      'logsBloom'
+    ]
+
+    for (let i = 0; i < transactionFields.length; i++) {
+      const key = transactionFields[i]
+      expect(tx[key], `tx.${key} should exist`).to.not.eq('undefined')
+    }
+
+    for (let i = 0; i < receiptFields.length; i++) {
+      const key = receiptFields[i]
+      expect(receipt[key], `receipt.${key} should exist`).to.not.eq('undefined')
+    }
+  })
+
+  it('getTransaction should return null for an unknown transaction', async function() {
+    const tx = await requestManager.getTransaction('0xfaceb00c')
+    expect(tx).to.be.null // tslint:disable-line
   })
 
   it('should get 0 mana balance by default', async () => {

--- a/test/unit.eth-return-types.ts
+++ b/test/unit.eth-return-types.ts
@@ -59,7 +59,7 @@ describe('test types', () => {
 
   test('web3_clientVersion', 'string')
   test('web3_sha3', 'string', 'asd')
-  test('net_version', 'number')
+  test('net_version', 'string')
   test('net_peerCount', 'number')
   test('net_listening', 'boolean')
   test('eth_protocolVersion', 'number')


### PR DESCRIPTION
This PR includes:

- `requestManager.getTransaction()` as seen in decentraland-eth
- Specific transaction types for status
-  A fix for net_version that should return `string`
- Tests as seen in decentraland-eth

Also see:
https://github.com/decentraland/decentraland-eth/blob/master/src/ethereum/txUtils.ts
https://github.com/decentraland/decentraland-eth/blob/master/specs/txUtils.spec.ts