### PR TITLE
fix: fix type errors on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ provision-bundled:
 		@cp ./static/api-extractor.json ./dist/api-extractor.json
 		@cp ./static/tsconfig.json ./dist/tsconfig.json
 		@cp ./static/esm.ts ./dist/esm.ts
-		@cd ./dist && npm install --no-save @microsoft/api-extractor
-		@cd ./dist && ./node_modules/.bin/api-extractor run --typescript-compiler-folder ./node_modules/typescript --local
-		npx @microsoft/api-documenter markdown --input-folder dist/dist --output-folder docs
+		@cd ./dist && npm install --no-save @microsoft/api-extractor@6.3.0
+		@cd ./dist && ./node_modules/.bin/api-extractor run --typescript-compiler-folder ./node_modules/typescript --local && sed -i '' 's,import("../utils/BigNumber").BigNumber,BigNumber,g' eth-connect.d.ts
+		npx @microsoft/api-documenter@1.5.58 markdown --input-folder dist/dist --output-folder docs
 		@mv docs/eth-connect.md docs/index.md
 		@mv ./dist/lib/eth-connect.js ./dist
 		@mv ./dist/lib/eth-connect.esm.js ./dist

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-codecov:
 
 local-node:
 		# ensure ethereum/client-go image
-		@docker pull ethereum/client-go
+		@docker pull ethereum/client-go:v1.8.27
 
 		# kill the previous ethereum/client-go container if exist
 		@(docker container kill geth-dev || true)
@@ -69,7 +69,7 @@ local-node:
 				-d --name geth-dev \
 				-v "$(PWD)":/eth_common \
 				-p 8545:8545 -p 8546:8546 \
-						ethereum/client-go \
+						ethereum/client-go:v1.8.27 \
 				--identity="TEST_NODE" --networkid="53611" \
 				--rpc --rpcaddr 0.0.0.0 --rpcapi admin,debug,eth,miner,net,personal,shh,txpool,web3 \
 				--ws  --wsaddr 0.0.0.0  --wsapi admin,debug,eth,miner,net,personal,shh,txpool,web3 --wsorigins \* \

--- a/static/package.json
+++ b/static/package.json
@@ -15,5 +15,8 @@
   ],
   "license": "LGPL-3.0",
   "main": "./eth-connect.js",
-  "typings": "./eth-connect.d.ts"
+  "typings": "./eth-connect.d.ts",
+  "dependencies": {
+    "fp-future": "^1.0.1"
+  }
 }


### PR DESCRIPTION
## The problem
Since https://github.com/decentraland/cli/pull/526, all scene errors are reported to content creators. However, some of them are seeing errors that are not related to their code, but they are type errors in `eth-connect`:

```
Error /node_modules/eth-connect/eth-connect.d.ts (1,25): Cannot find module 'fp-future'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
Error /node_modules/eth-connect/eth-connect.d.ts (985,41): Cannot find module '../utils/BigNumber'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
Error /node_modules/eth-connect/eth-connect.d.ts (1013,41): Cannot find module '../utils/BigNumber'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?
```

On one side, we are not marking `fp-future` as a dependency. On the other, some methods look like this:
```const eth_getBalance: Method<import("../utils/BigNumber").BigNumber>;```
when they should look like this:
```const eth_getBalance: Method<BigNumber>;```

## Changes made
First, we specified the last working version of the api-extractor libs and eth-client we are using, because newer versions have breaking changes.

Then, we added `fp-future` as a dependency.

Lastly, I couldn't find a way for `api-extractor` to avoid the relative import, so we are doing it manually.