### PR TITLE
fix: valid undefined error

### DIFF
--- a/src/providers/WebSocketProvider.ts
+++ b/src/providers/WebSocketProvider.ts
@@ -180,8 +180,8 @@ export class WebSocketProvider<T extends IWebSocket> {
 
       this.responseCallbacks.delete(id)
 
-      if ('error' in message) {
-        defer.reject(Object.assign(new Error(message.error.message || message.error), message.error))
+      if ('error' in message && message.error !== undefined && message.error !== null) {
+        defer.reject(Object.assign(new Error((message.error as any).message || message.error), message.error))
       } else if ('result' in message) {
         defer.resolve(message)
       }

--- a/src/providers/WebSocketProvider.ts
+++ b/src/providers/WebSocketProvider.ts
@@ -180,7 +180,7 @@ export class WebSocketProvider<T extends IWebSocket> {
 
       this.responseCallbacks.delete(id)
 
-      if ('error' in message && message.error !== undefined && message.error !== null) {
+      if (message.error !== undefined && message.error !== null) {
         defer.reject(Object.assign(new Error((message.error as any).message || message.error), message.error))
       } else if ('result' in message) {
         defer.resolve(message)

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -10,7 +10,7 @@ export type RPCMessage = {
 export type RPCError = {
   jsonrpc: '2.0'
   id: number
-  error: any
+  error: string | number | boolean | symbol | Object
 }
 
 export type RPCResponse =
@@ -19,6 +19,7 @@ export type RPCResponse =
       jsonrpc: '2.0'
       id: number
       result: any
+      error?: undefined | null
     }
 
 export function toRPC(message: RPCMessage): RPCMessage {

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -10,7 +10,7 @@ export type RPCMessage = {
 export type RPCError = {
   jsonrpc: '2.0'
   id: number
-  error: string | number | boolean | symbol | Object
+  error: string | number | boolean | symbol | object
 }
 
 export type RPCResponse =

--- a/src/utils/jsonrpc.ts
+++ b/src/utils/jsonrpc.ts
@@ -55,7 +55,7 @@ export function isValidResponse(response: RPCResponse | RPCResponse[]) {
   function validateSingleMessage(message: RPCResponse) {
     return (
       !!message &&
-      (!('error' in message) || message.error === undefined || message.error === null) &&
+      (message.error === undefined || message.error === null) &&
       message.jsonrpc === '2.0' &&
       typeof message.id === 'number' &&
       'result' in message &&

--- a/src/utils/jsonrpc.ts
+++ b/src/utils/jsonrpc.ts
@@ -55,9 +55,10 @@ export function isValidResponse(response: RPCResponse | RPCResponse[]) {
   function validateSingleMessage(message: RPCResponse) {
     return (
       !!message &&
-      !('error' in message) &&
+      (!('error' in message) || message.error === undefined || message.error === null) &&
       message.jsonrpc === '2.0' &&
       typeof message.id === 'number' &&
+      'result' in message &&
       message.result !== undefined
     ) // only undefined is not valid json object
     // the null is not a valid response for rpc nodes

--- a/test/jsonrpc.isValidResponse.spec.ts
+++ b/test/jsonrpc.isValidResponse.spec.ts
@@ -130,5 +130,34 @@ describe('jsonrpc', function () {
       // then
       expect(valid).toEqual(true)
     })
+
+    it('should validate jsonrpc response with result and undefined error', () => {
+      let response: RPCResponse = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: "3",
+        error: undefined
+      }
+      expect(Jsonrpc.isValidResponse(response)).toEqual(true)
+    })
+
+    it('should validate jsonrpc response with result and null error', () => {
+      let response: RPCResponse = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: "3",
+        error: null
+      }
+      expect(Jsonrpc.isValidResponse(response)).toEqual(true)
+    })
+
+    it('should validate jsonrpc response with error', () => {
+      let response: RPCResponse = {
+        jsonrpc: '2.0',
+        id: 1,
+        error: "23"
+      }
+      expect(Jsonrpc.isValidResponse(response)).toEqual(false)
+    })
   })
 })


### PR DESCRIPTION
In some cases (reproducible in firefox) the result of an rpc call had the key `error` defined with its value as undefined. This handle that case as to be a valid rpc result if it complies with all other requirements

#### Before
```ts
> isValidResponse({ result: "3", id: 4, jsonrpc: "2.0", error: undefined })
> false
```


#### Now
```ts
> isValidResponse({ result: "3", id: 4, jsonrpc: "2.0", error: undefined })
> true
```

https://github.com/decentraland/unity-renderer/issues/5999