### PR TITLE
fix: temporarily remove id validation

### DIFF
--- a/src/utils/jsonrpc.ts
+++ b/src/utils/jsonrpc.ts
@@ -57,7 +57,7 @@ export function isValidResponse(response: RPCResponse | RPCResponse[]) {
       !!message &&
       (message.error === undefined || message.error === null) &&
       message.jsonrpc === '2.0' &&
-      typeof message.id === 'number' &&
+      message.id !== null &&
       'result' in message &&
       message.result !== undefined
     ) // only undefined is not valid json object

--- a/test/jsonrpc.isValidResponse.spec.ts
+++ b/test/jsonrpc.isValidResponse.spec.ts
@@ -58,10 +58,11 @@ describe('jsonrpc', function () {
       expect(valid).toEqual(false)
     })
 
-    it('should validate jsonrpc response without id number', function () {
+    it('should validate jsonrpc response without id', function () {
       // given
       let response: any = {
         jsonrpc: '2.0',
+        id: null,
         result: []
       }
 
@@ -72,7 +73,7 @@ describe('jsonrpc', function () {
       expect(valid).toEqual(false)
     })
 
-    it('should validate jsonrpc response with wrong id field', function () {
+    it('should validate jsonrpc response with id', function () {
       // given
       let response: any = {
         jsonrpc: '2.0',
@@ -84,7 +85,7 @@ describe('jsonrpc', function () {
       let valid = Jsonrpc.isValidResponse(response)
 
       // then
-      expect(valid).toEqual(false)
+      expect(valid).toEqual(true)
     })
 
     it('should validate jsonrpc response without result field', function () {


### PR DESCRIPTION
Magic is returning `id=''` for one of the rpc calls. This PR temporarily removes the number validation for id property until they fix the issue on their side