### PR TITLE
feat: accept the native fetch directly as the HTTPProvider fetch option

### DIFF
--- a/docs/eth-connect.fetchfunction.md
+++ b/docs/eth-connect.fetchfunction.md
@@ -10,7 +10,6 @@
 export type FetchFunction = (url: string, params: {
     body?: any;
     method?: string;
-    mode?: string;
     headers?: any;
 }) => Promise<any>;
 ```

--- a/report/eth-connect.api.md
+++ b/report/eth-connect.api.md
@@ -880,7 +880,6 @@ export function extractTypeName(name: string): string;
 export type FetchFunction = (url: string, params: {
     body?: any;
     method?: string;
-    mode?: string;
     headers?: any;
 }) => Promise<any>;
 

--- a/src/providers/HTTPProvider.ts
+++ b/src/providers/HTTPProvider.ts
@@ -1,12 +1,16 @@
 import { RPCMessage, Callback, toRPC } from './common'
 export { RPCMessage, Callback } from './common'
 
+// Structurally compatible with the global native `fetch` (the same WHATWG signature on web
+// and server) as well as native-fetch components (e.g. @dcl/fetch-component) and node-fetch,
+// so callers can pass any of them directly without a cast. Only the fields HTTPProvider sets
+// are listed; a previous `mode?: string` was dropped because it is unused here and made the
+// native fetch's `RequestInit` (`mode?: RequestMode`) non-assignable to this type.
 export type FetchFunction = (
   url: string,
   params: {
     body?: any
     method?: string
-    mode?: string
     headers?: any
   }
 ) => Promise<any>

--- a/test/HTTPProvider.spec.ts
+++ b/test/HTTPProvider.spec.ts
@@ -1,4 +1,4 @@
-import { HTTPProvider } from '../src/providers/HTTPProvider'
+import { HTTPProvider, HTTPProviderOptions } from '../src/providers/HTTPProvider'
 
 type SendResult = { err: Error | null; result: any }
 
@@ -107,6 +107,28 @@ describe('when sending an async request through the HTTPProvider', () => {
       const { result } = await sendAsync(provider, payload)
 
       expect(result.result).toBe('0x1')
+    })
+  })
+})
+
+describe('when configuring the fetch option', () => {
+  describe('and the global native fetch is supplied', () => {
+    it('should be accepted without a cast', () => {
+      // This compiles only if the global native fetch (same WHATWG signature on web and
+      // server) is assignable to the fetch option — the point of this change.
+      const options: HTTPProviderOptions = { fetch: globalThis.fetch }
+
+      expect(typeof options.fetch).toBe('function')
+    })
+  })
+
+  describe('and a native-fetch component is supplied', () => {
+    it('should be accepted without a cast', () => {
+      // Mirrors the shape of native-fetch components such as @dcl/fetch-component.
+      const fetchComponent: (url: string, init?: RequestInit) => Promise<Response> = globalThis.fetch
+      const options: HTTPProviderOptions = { fetch: fetchComponent }
+
+      expect(typeof options.fetch).toBe('function')
     })
   })
 })


### PR DESCRIPTION
## Problem

`HTTPProvider`'s `FetchFunction` option typed its params with `mode?: string`:

```ts
export type FetchFunction = (url: string, params: { body?: any; method?: string; mode?: string; headers?: any }) => Promise<any>
```

The global native `fetch` types its init as `RequestInit`, whose `mode` is `RequestMode` (a string union). Since `string` is **not** assignable to `RequestMode`, the native fetch is not assignable to `FetchFunction`, so every caller has to cast:

```ts
new HTTPProvider(url, { fetch: fetch.fetch as unknown as FetchFunction })   // 👎 cast
```

## Fix

`HTTPProvider` never sets `mode` (it only sends `body`/`method`/`headers`), so the field is dead weight. Dropping it makes the option accept, **with no cast**:

- the **global native `fetch`** — the same WHATWG signature on web and server;
- native-fetch **components** (e.g. `@dcl/fetch-component`'s `fetch`);
- and **node-fetch** (still assignable — existing callers keep compiling).

```ts
new HTTPProvider(url, { fetch: globalThis.fetch })   // ✅ no cast
```

This is a **type-only** change — the emitted JS is identical, so there is no runtime/behavior change.

## Tests

Added compile-time assertions in `test/HTTPProvider.spec.ts` that `globalThis.fetch` and a native-fetch-component-shaped function are assignable to the option without a cast. The existing `node-fetch` integration spec still typechecks.

## Verification

- `tsc` src + full test project (incl. the node-fetch integration spec): clean
- unit suite: 10/10
- `make build`: succeeds; API report regenerated (idempotent) and committed; docs updated
- lint: clean

## Follow-up

Once published, consumers can drop their `as unknown as FetchFunction` casts (e.g. archipelago-workers' `ws-connector`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
